### PR TITLE
use default bundle if system locale is unsupported

### DIFF
--- a/FlagMaker/src/flagmaker/Files/LocalizationHandler.java
+++ b/FlagMaker/src/flagmaker/Files/LocalizationHandler.java
@@ -18,8 +18,8 @@ public class LocalizationHandler
 	{
 		_currentLocale = GetLocalePreference();
 		if (_currentLocale == null) _currentLocale = Locale.US;
-		SetBundle(_currentLocale);
 		_defaultBundle = ResourceBundle.getBundle("bundles.strings", Locale.US);
+		SetBundle(_currentLocale);
 	}
 	
 	public static void SetLanguage(Locale locale)
@@ -43,7 +43,13 @@ public class LocalizationHandler
 	
 	private static void SetBundle(Locale locale)
 	{
-		_bundle = ResourceBundle.getBundle("bundles.strings", locale);
+		try {
+			_bundle = ResourceBundle.getBundle("bundles.strings", locale);
+		}
+		catch (Exception e)
+		{
+			_bundle = _defaultBundle;
+		}
 	}
 	
 	private static Locale GetLocalePreference()


### PR DESCRIPTION
This fixes the problem of the application crashing when there is no bundle for the system locale (this problem can be reproduced by launching with `java -Duser.country=DE -Duser.language=de -jar FlagMaker.jar`).